### PR TITLE
Updating repository to perform automated coverage testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,19 @@ sudo: false
 language: python
 python:
   - "2.7"
+env:
+  global:
+    - NIFTY_TRAVIS_CACHE_REPO=https://github.com/nimbis/travis-cache-public.git
 install:
   - make reqs
+before_script:
+  - git clone https://github.com/nimbis/nifty.git ./.nifty
 script:
+  - source .nifty/nifty-script
+  - verify_coverage_improvement
   - make pep8
   - make flake8
   - make test
-  - make coverage
   - make doc
 after_success:
   - coveralls


### PR DESCRIPTION
These changes utilize `nifty` to perform automated coverage
comparison testing using information regarding the master branch's code
test coverage from the travis-cache repository. Builds will now fail if
total test coverage drops below the current value for the master branch
that is stored in the travis-cache-public repository.