### PR TITLE
Compatibility with django-cms 3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ adding some additional functionality, such as images.
 Requires
 ----------------
 
-* django-cms >= 2.4
-* django >= 1.4
+* django-cms >= 3.3
+* django >= 1.8
 * djangocms-text-ckeditor >= 2.0
 
 

--- a/cmsplugin_newsplus/cms_apps.py
+++ b/cmsplugin_newsplus/cms_apps.py
@@ -7,8 +7,10 @@ from .menu import NewsItemMenu
 
 
 class NewsAppHook(CMSApp):
+    app_name = 'cmsplugin_newsplus'
     name = _('News App')
-    urls = []
+    def get_urls(self, page=None, language=None, **kwargs):
+        return ['cmsplugin_newsplus.urls']
     menus = [NewsItemMenu]
 
 

--- a/cmsplugin_newsplus/feeds.py
+++ b/cmsplugin_newsplus/feeds.py
@@ -14,7 +14,7 @@ class NewsFeed(Feed):
 
     @property
     def link(self):
-        return reverse('news_archive_index')
+        return reverse('cmsplugin_newsplus:news_archive_index')
 
     def items(self):
         return models.News.published.all()[:settings.FEED_SIZE]

--- a/cmsplugin_newsplus/models.py
+++ b/cmsplugin_newsplus/models.py
@@ -61,7 +61,7 @@ class News(models.Model):
         if settings.LINK_AS_ABSOLUTE_URL and self.link:
             if settings.USE_LINK_ON_EMPTY_CONTENT_ONLY and not self.content:
                 return self.link
-        return reverse('news_detail',
+        return reverse('cmsplugin_newsplus:news_detail',
                        kwargs={'year': self.pub_date.strftime("%Y"),
                                'month': self.pub_date.strftime("%m"),
                                'day': self.pub_date.strftime("%d"),

--- a/cmsplugin_newsplus/navigation.py
+++ b/cmsplugin_newsplus/navigation.py
@@ -27,7 +27,7 @@ def get_nodes(request):
         if date.year not in years_done:
             years_done.append(date.year)
             year_node = NavigationNode(date.year,
-                                       reverse('news_archive_year',
+                                       reverse('cmsplugin_newsplus:news_archive_year',
                                                kwargs=dict(year=date.year)),
                                        'newsitem-year-%d' % (date.year,))
             year_node.childrens = []
@@ -38,7 +38,7 @@ def get_nodes(request):
             months_done.append(date.month)
             month_node = NavigationNode(
                 datetime.strftime(date, '%B'),
-                reverse('news_archive_month', kwargs=dict(
+                reverse('cmsplugin_newsplus:news_archive_month', kwargs=dict(
                     year=date.year,
                     month=datetime.strftime(date, '%m'))),
                 'newsitem-month-%d.%d' % (
@@ -52,7 +52,7 @@ def get_nodes(request):
             days_done.append(date.day)
             day_node = NavigationNode(
                 datetime.strftime(date, '%d'),
-                reverse('news_archive_day', kwargs=dict(
+                reverse('cmsplugin_newsplus:news_archive_day', kwargs=dict(
                     year=date.year,
                     month=datetime.strftime(date, '%m'),
                     day=datetime.strftime(date, '%d'))),

--- a/cmsplugin_newsplus/templates/cmsplugin_newsplus/news_archive_year.html
+++ b/cmsplugin_newsplus/templates/cmsplugin_newsplus/news_archive_year.html
@@ -3,7 +3,7 @@
 <ul>
 {% for date in date_list %}
   <li>
-    <a href="{% url 'news_archive_month' year=date|date:'Y' month=date|date:'m'  %}">{{ date|date:"F" }}</a>
+    <a href="{% url 'cmsplugin_newsplus:news_archive_month' year=date|date:'Y' month=date|date:'m'  %}">{{ date|date:"F" }}</a>
   </li>
 {% empty %}
   <li>No news for this year</li>

--- a/cmsplugin_newsplus/urls.py
+++ b/cmsplugin_newsplus/urls.py
@@ -3,7 +3,7 @@ from django.conf.urls import url
 from . import feeds
 from . import views
 
-
+app_name = 'cmsplugin_newsplus'
 urlpatterns = [
     url(r'^$',
         views.ArchiveIndexView.as_view(), name='news_archive_index'),

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,8 @@ setup(
     ],
     include_package_data=True,
     install_requires=[
-        'Django',
-        'django-cms >= 2.4',
+        'Django >= 1.8',
+        'django-cms >= 3.3',
         'djangocms-text-ckeditor >= 2.0',
         'Pillow',
     ],


### PR DESCRIPTION
Django cms 3.3 depends on Django 1.8. In that Django version the url namespaces are required. This PR mainly brings the url namespacing to cmsplugin-newsplus.

Also the urls-property on the app hook is deprecated and replaced with get_urls()